### PR TITLE
Debug

### DIFF
--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -36,8 +36,9 @@ module Mjml
     def run(in_tmp_file, beautify=true, minify=false)
       Tempfile.create(["out", ".html"]) do |out_tmp_file|
         command = "#{mjml_bin} -r #{in_tmp_file} -o #{out_tmp_file.path} --config.beautify #{beautify} --config.minify #{minify}"
-        _, _, stderr, _ = Open3.popen3(command)
-        raise ParseError.new(stderr.read.chomp) unless stderr.eof?
+        Open3.popen3(command) do |_, _, stderr, _|
+          raise ParseError.new(stderr.read.chomp) unless stderr.eof?
+        end
         out_tmp_file.read
       end
     end

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -40,11 +40,11 @@ module Mjml
           if !stderr.eof?
             raise ParseError.new(stderr.read.chomp)
           elsif !wait_thr.value.success?
-            raise ParseError.new("mjml exited non-zero exit status: #{wait_thr.value.exitstatus}")
+            Mjml.logger.error "mjml exited non-zero exit status: #{wait_thr.value.exitstatus}"
           end
         end
         result = out_tmp_file.read
-        raise ParseError.new('mjml returned empty string') if result.empty?
+        Mjml.logger.error 'mjml returned empty string' if result.empty?
         result
       end
     end

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -23,8 +23,8 @@ module Mjml
         file # return tempfile from block so #unlink works later
       end
       run(in_tmp_file.path, Mjml.beautify, Mjml.minify)
-    rescue
-      raise if Mjml.raise_render_exception
+    rescue => e
+      raise e if Mjml.raise_render_exception
       ""
     ensure
       in_tmp_file.unlink

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -43,7 +43,9 @@ module Mjml
             raise ParseError.new("mjml exited non-zero exit status: #{wait_thr.value.exitstatus}")
           end
         end
-        out_tmp_file.read
+        result = out_tmp_file.read
+        raise ParseError.new('mjml returned empty string') if result.empty?
+        result
       end
     end
 


### PR DESCRIPTION
HTMLメールの本文が空になる問題について、mjml-rails内で検証してみます。

- stderrになんらかの文字列が出力されたとき（すでにこのときは例外あげるようになってる）

に加えて、

- mjmlのexit statusが0以外のとき
- 出力されたhtmlが空のとき

にログを出すようにしてみました。

たぶん「mjmlのexit statusが0かつstderrに何も出力されないけど、htmlが空」って状態だと思うので、そうしたら結果を一時ファイルに書くんじゃなくて標準出力から取るようにしてみます。
それでもだめならmjml-railsは悪くなさそうなので本体に入っていかないといけないかなあ